### PR TITLE
Running tahiti with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:2.7-onbuild
+MAINTAINER Guilherme Maluf <guimalufb@gmail.com>
+
+EXPOSE 5000
+CMD [ "python", "./tahiti/app_api.py", "-c", "tahiti.json" ]

--- a/README.md
+++ b/README.md
@@ -33,3 +33,17 @@ Edit `tahiti.json` according to your database config
 ```
 python tahiti/app_api.py -c tahiti.json
 ```
+
+#### Using docker
+Build the container
+```
+docker build -t bigsea/tahiti .
+```
+
+Repeat [config](#config) stop and run using config file
+```
+docker run \
+  -v $PWD/tahiti.json:/usr/src/app/tahiti.json \
+  -p 5000:5000 \
+  bigsea/tahiti
+```


### PR DESCRIPTION
Includes Dockerfile based on python:2.7 container which install
requimentes.txt and run app_api based on README instructions
