### PR TITLE
remove unicode module

### DIFF
--- a/migrations/versions/a569f5a6c2d8_add_keras_layers.py
+++ b/migrations/versions/a569f5a6c2d8_add_keras_layers.py
@@ -3689,7 +3689,7 @@ def upgrade():
 
     try:
         for cmd in all_commands:
-            if isinstance(cmd[0], (unicode, str)):
+            if isinstance(cmd[0], str):
                 connection.execute(cmd[0])
             elif isinstance(cmd[0], list):
                 for row in cmd[0]:
@@ -3711,7 +3711,7 @@ def downgrade():
         connection.execute('SET FOREIGN_KEY_CHECKS=0;')
         for cmd in reversed(all_commands):
             if cmd[1]:
-                if isinstance(cmd[1], (unicode, str)):
+                if isinstance(cmd[1], str):
                     connection.execute(cmd[1])
                 elif isinstance(cmd[1], list):
                     for row in cmd[1]:


### PR DESCRIPTION
Removing 'unicode' (available only in python2.X) from migration code.