### PR TITLE
Transforming the Metric to evaluation into a mandatory field

### DIFF
--- a/migrations/versions/2b4ce751c4de_fixing_evaluator_model.py
+++ b/migrations/versions/2b4ce751c4de_fixing_evaluator_model.py
@@ -1,7 +1,7 @@
 """fixing evaluator model
 
 Revision ID: 2b4ce751c4de
-Revises: 473036c8f99f
+Revises: 05985c3f83ca
 Create Date: 2020-07-14 16:36:06.492737
 
 """
@@ -14,7 +14,7 @@ from sqlalchemy.sql import table, column
 
 # revision identifiers, used by Alembic.
 revision = '2b4ce751c4de'
-down_revision = '473036c8f99f'
+down_revision = '05985c3f83ca'
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/2b4ce751c4de_fixing_evaluator_model.py
+++ b/migrations/versions/2b4ce751c4de_fixing_evaluator_model.py
@@ -1,0 +1,66 @@
+"""fixing evaluator model
+
+Revision ID: 2b4ce751c4de
+Revises: 473036c8f99f
+Create Date: 2020-07-14 16:36:06.492737
+
+"""
+from alembic import context
+from alembic import op
+from sqlalchemy import String, Integer, Text
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.sql import table, column
+
+
+# revision identifiers, used by Alembic.
+revision = '2b4ce751c4de'
+down_revision = '473036c8f99f'
+branch_labels = None
+depends_on = None
+
+all_commands = [
+    ("UPDATE operation_form_field SET required = 1 WHERE id=101",
+     "UPDATE operation_form_field SET required = 0 WHERE id=101")
+]
+
+
+def upgrade():
+    ctx = context.get_context()
+    session = sessionmaker(bind=ctx.bind)()
+    connection = session.connection()
+
+    try:
+        for cmd in all_commands:
+            if isinstance(cmd[0], str):
+                connection.execute(cmd[0])
+            elif isinstance(cmd[0], list):
+                for row in cmd[0]:
+                    connection.execute(row)
+            else:
+                cmd[0]()
+    except:
+        session.rollback()
+        raise
+    session.commit()
+
+
+def downgrade():
+    ctx = context.get_context()
+    session = sessionmaker(bind=ctx.bind)()
+    connection = session.connection()
+
+    try:
+        connection.execute('SET FOREIGN_KEY_CHECKS=0;')
+        for cmd in reversed(all_commands):
+            if isinstance(cmd[1], str):
+                connection.execute(cmd[1])
+            elif isinstance(cmd[1], list):
+                for row in cmd[1]:
+                    connection.execute(row)
+            else:
+                cmd[1]()
+        connection.execute('SET FOREIGN_KEY_CHECKS=1;')
+    except:
+        session.rollback()
+        raise
+    session.commit()

--- a/migrations/versions/2b4ce751c4de_fixing_evaluator_model.py
+++ b/migrations/versions/2b4ce751c4de_fixing_evaluator_model.py
@@ -1,7 +1,7 @@
 """fixing evaluator model
 
 Revision ID: 2b4ce751c4de
-Revises: 05985c3f83ca
+Revises: aea8dea22277
 Create Date: 2020-07-14 16:36:06.492737
 
 """
@@ -14,7 +14,7 @@ from sqlalchemy.sql import table, column
 
 # revision identifiers, used by Alembic.
 revision = '2b4ce751c4de'
-down_revision = '05985c3f83ca'
+down_revision = 'aea8dea22277'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
This pull request fixes [issue#203](https://github.com/eubr-bigsea/citrus/issues/203) by transforming the Metric to the evaluation into a mandatory field.