### PR TITLE
Remove operations from spark platform

### DIFF
--- a/migrations/versions/a4c87d04f18e_tokenize.py
+++ b/migrations/versions/a4c87d04f18e_tokenize.py
@@ -126,15 +126,10 @@ def _insert_operation_platform(conn):
     )
     columns = [c.name for c in tb.columns]
     data = [
-	[BASE_OP + 1, 1],
 	[BASE_OP + 1, 4],
-        [BASE_OP + 2, 1],
         [BASE_OP + 2, 4],
-        [BASE_OP + 3, 1],
         [BASE_OP + 3, 4],
-        [BASE_OP + 4, 1],
         [BASE_OP + 4, 4],
-        [BASE_OP + 5, 1],
         [BASE_OP + 5, 4]
     ]
 

--- a/migrations/versions/a6b3c5df78e8_normalizer.py
+++ b/migrations/versions/a6b3c5df78e8_normalizer.py
@@ -119,15 +119,10 @@ def _insert_operation_platform(conn):
     )
     columns = [c.name for c in tb.columns]
     data = [
-	[BASE_OP + 1, 1],
 	[BASE_OP + 1, 4],
-    [BASE_OP + 2, 1],
     [BASE_OP + 2, 4],
-    [BASE_OP + 3, 1],
     [BASE_OP + 3, 4],
-    [BASE_OP + 4, 1],
     [BASE_OP + 4, 4],
-    [BASE_OP + 5, 1],
     [BASE_OP + 5, 4]
     ]
 

--- a/migrations/versions/f1ff40611872_pdf_cdf_ccdf.py
+++ b/migrations/versions/f1ff40611872_pdf_cdf_ccdf.py
@@ -127,12 +127,9 @@ def _insert_operation_platform(conn):
     )
     columns = [c.name for c in tb.columns]
     data = [
-	[BASE_OP + 1, 1],
 	[BASE_OP + 1, 4],
-	[BASE_OP + 2, 1],
 	[BASE_OP + 2, 4],
 	[BASE_OP + 3, 4],
-	[BASE_OP + 4, 1],
 	[BASE_OP + 4, 4],
     ]
 


### PR DESCRIPTION
Some specific operations are defined only in scikit learn platform and should not appear on spark.